### PR TITLE
Name consolidation

### DIFF
--- a/rfcs/12-primitive-shapes.md
+++ b/rfcs/12-primitive-shapes.md
@@ -417,28 +417,28 @@ impl Collider2d for CircleCollider {}
 
 // Box Types
 
-struct Box2d {
+struct Rectangle {
   half_extents: Vec2,
 }
-impl Meshable for Box2d
+impl Meshable for Rectangle
 
 /* REFERENCE ONLY
 struct BoundingBox2d {
-  box: Box2d,
+  box: Rectangle,
   translation: Vec2,
 }
 impl Meshable for BoundingBox2d {}
 impl Bounding2d for BoundingBox2d {}
 type Aabb2d = BoundingBox2d;
 
-struct BoxCollider2d {
-  box: Box2d,
+struct RectangleCollider {
+  box: Rectangle,
   translation: Vec2,
   rotation: Mat2,
 }
-impl Meshable for BoxCollider2d {}
-impl Collider2d for BoxCollider2d {}
-type Obb2d = BoxCollider2d;
+impl Meshable for RectangleCollider {}
+impl Collider2d for RectangleCollider {}
+type Obb2d = RectangleCollider;
 */
 
 // Capsule Types

--- a/rfcs/12-primitive-shapes.md
+++ b/rfcs/12-primitive-shapes.md
@@ -76,6 +76,10 @@ This RFC provides independent 2d and 3d primitives. Recall that the purpose of t
 
 | Shape           | 2D              | 3D            |
 |-----------------|-----------------|---------------|
+| Rectangle       | Rectangle       | -             |
+| Circle          | Circle          | -             |
+| Polygon         | Polygon         | -             |
+| RegularPolygon  | RegularPolygon  | -             |
 | Point           | Point2d         | Point3d       |
 | Plane           | Plane2d         | Plane3d       |
 | Direction       | Direction2d     | Direction3d   |
@@ -93,11 +97,6 @@ This RFC provides independent 2d and 3d primitives. Recall that the purpose of t
 | Wedge           | -               | Wedge         |
 | Torus           | -               | Torus         |
 | Frustum         | -               | Frustum       |
-| RegularPolygon  | RegularPolygon  | -             |
-| Polygon         | Polygon         | -             |
-| Rectangle       | Rectangle       | -             |
-| Circle          | Circle          | -             |
-
 
 ## Implementation strategy
 

--- a/rfcs/12-primitive-shapes.md
+++ b/rfcs/12-primitive-shapes.md
@@ -136,6 +136,129 @@ trait Collider2d {
   fn within(&self, bounds: &impl Bounding2d) -> bool;
 }
 ```
+### 2D Geometry Types
+
+These types only exist in 2d space: their dimensions and location are only defined in `x` and `y` unlike their 3d counterparts. These types are suffixed with "2d" to disambiguate from the 3d types in user code, guide users to using 3d types by default, and remove the need for name-spacing the 2d and 3d types when used in the same scope.
+
+```rust
+struct Point2d(Vec2)
+
+struct Direction2d(Vec2)
+impl Meshable for Direction2d {}
+
+struct Ray2d {
+  point: Point2d, 
+  direction: Direction2d
+}
+impl Meshable for Ray2d {}
+
+struct Line2d {
+  point: Point2d, 
+  direction: Direction2d,
+}
+impl Meshable for Line2d {}
+
+struct LineSegment2d { 
+  start: Point2d, 
+  end: Point2d,
+}
+impl Meshable for LineSegment2d {}
+
+struct PolyLine2d<const N: usize>{
+  points: [Point2d; N],
+}
+impl Meshable for PolyLine2d {}
+
+struct Triangle2d([Point2d; 3]);
+impl Meshable for Triangle2d {}
+
+struct Quad2d([Point2d; 4]);
+impl Meshable for Quad2d {}
+
+/// A regular polygon, such as a square or hexagon.
+struct RegularPolygon2d {
+  /// The circumcircle that all points of the regular polygon lie on.
+  circumcircle: Circle2d,
+  /// Number of faces.
+  faces: u8,
+  /// Clockwise rotation of the polygon about the origin. At zero rotation, a point will always be located at the 12 o'clock position.
+  orientation: Angle,
+}
+impl Meshable for RegularPolygon2d {}
+ 
+struct Polygon2d <const N: usize>{
+  points: [Point2d; N],
+}
+impl Meshable for Polygon2d {}
+
+/// Circle types
+
+struct Circle {
+  radius: f32,
+}
+impl Meshable for Circle {}
+
+/* REFERENCE ONLY
+struct BoundingCircle2d {
+  circle: Circle,
+  translation: Vec2,
+}
+impl Meshable for BoundingCircle2d {}
+impl Bounding2d for BoundingCircle2d {}
+
+struct CircleCollider {
+  sphere: Circle,
+  translation: Vec2,
+}
+impl Meshable for CircleCollider {}
+impl Collider2d for CircleCollider {}
+*/
+
+// Box Types
+
+struct Rectangle {
+  half_extents: Vec2,
+}
+impl Meshable for Rectangle
+
+/* REFERENCE ONLY
+struct BoundingBox2d {
+  box: Rectangle,
+  translation: Vec2,
+}
+impl Meshable for BoundingBox2d {}
+impl Bounding2d for BoundingBox2d {}
+type Aabb2d = BoundingBox2d;
+
+struct RectangleCollider {
+  box: Rectangle,
+  translation: Vec2,
+  rotation: Mat2,
+}
+impl Meshable for RectangleCollider {}
+impl Collider2d for RectangleCollider {}
+type Obb2d = RectangleCollider;
+*/
+
+// Capsule Types
+
+struct Capsule2d {
+  height: f32, // Height of the rectangular section
+  radius: f32, // End cap radius
+}
+impl Meshable for Capsule2d {}
+
+/* REFERENCE ONLY
+struct CapsuleCollider2d {
+  capsule: Capsule2d,
+  translation: Vec2,
+  rotation: Mat2,
+}
+impl Meshable for CapsuleCollider2d {}
+impl Collider2d for CapsuleCollider2d {}
+*/
+
+```
 
 ### 3D Geometry Types
 
@@ -336,129 +459,6 @@ impl Meshable for Frustum {}
 
 ```
 
-### 2D Geometry Types
-
-These types only exist in 2d space: their dimensions and location are only defined in `x` and `y` unlike their 3d counterparts. These types are suffixed with "2d" to disambiguate from the 3d types in user code, guide users to using 3d types by default, and remove the need for name-spacing the 2d and 3d types when used in the same scope.
-
-```rust
-struct Point2d(Vec2)
-
-struct Direction2d(Vec2)
-impl Meshable for Direction2d {}
-
-struct Ray2d {
-  point: Point2d, 
-  direction: Direction2d
-}
-impl Meshable for Ray2d {}
-
-struct Line2d {
-  point: Point2d, 
-  direction: Direction2d,
-}
-impl Meshable for Line2d {}
-
-struct LineSegment2d { 
-  start: Point2d, 
-  end: Point2d,
-}
-impl Meshable for LineSegment2d {}
-
-struct PolyLine2d<const N: usize>{
-  points: [Point2d; N],
-}
-impl Meshable for PolyLine2d {}
-
-struct Triangle2d([Point2d; 3]);
-impl Meshable for Triangle2d {}
-
-struct Quad2d([Point2d; 4]);
-impl Meshable for Quad2d {}
-
-/// A regular polygon, such as a square or hexagon.
-struct RegularPolygon2d {
-  /// The circumcircle that all points of the regular polygon lie on.
-  circumcircle: Circle2d,
-  /// Number of faces.
-  faces: u8,
-  /// Clockwise rotation of the polygon about the origin. At zero rotation, a point will always be located at the 12 o'clock position.
-  orientation: Angle,
-}
-impl Meshable for RegularPolygon2d {}
- 
-struct Polygon2d <const N: usize>{
-  points: [Point2d; N],
-}
-impl Meshable for Polygon2d {}
-
-/// Circle types
-
-struct Circle {
-  radius: f32,
-}
-impl Meshable for Circle {}
-
-/* REFERENCE ONLY
-struct BoundingCircle2d {
-  circle: Circle,
-  translation: Vec2,
-}
-impl Meshable for BoundingCircle2d {}
-impl Bounding2d for BoundingCircle2d {}
-
-struct CircleCollider {
-  sphere: Circle,
-  translation: Vec2,
-}
-impl Meshable for CircleCollider {}
-impl Collider2d for CircleCollider {}
-*/
-
-// Box Types
-
-struct Rectangle {
-  half_extents: Vec2,
-}
-impl Meshable for Rectangle
-
-/* REFERENCE ONLY
-struct BoundingBox2d {
-  box: Rectangle,
-  translation: Vec2,
-}
-impl Meshable for BoundingBox2d {}
-impl Bounding2d for BoundingBox2d {}
-type Aabb2d = BoundingBox2d;
-
-struct RectangleCollider {
-  box: Rectangle,
-  translation: Vec2,
-  rotation: Mat2,
-}
-impl Meshable for RectangleCollider {}
-impl Collider2d for RectangleCollider {}
-type Obb2d = RectangleCollider;
-*/
-
-// Capsule Types
-
-struct Capsule2d {
-  height: f32, // Height of the rectangular section
-  radius: f32, // End cap radius
-}
-impl Meshable for Capsule2d {}
-
-/* REFERENCE ONLY
-struct CapsuleCollider2d {
-  capsule: Capsule2d,
-  translation: Vec2,
-  rotation: Mat2,
-}
-impl Meshable for CapsuleCollider2d {}
-impl Collider2d for CapsuleCollider2d {}
-*/
-
-```
 
 ### Bounding and Collision
 

--- a/rfcs/12-primitive-shapes.md
+++ b/rfcs/12-primitive-shapes.md
@@ -100,7 +100,7 @@ The complete overview of shapes, their dimensions and their names can be seen in
 | Capsule         | -               | Capsule       | A capsule with its origin at the center of the volume                                    |
 | Cone            | -               | Cone          | A cone with the origin located at the center of the circular base                        |
 | Wedge           | -               | Wedge         | A ramp with the origin centered on the width, and coincident with the rear vertical wall |
-| Torus           | -               | Torus         | A torus, shaped like a donut                                                                           |
+| Torus           | -               | Torus         | A torus, shaped like a donut                                                             |
 | Frustum         | -               | Frustum       | The portion of a pyramid that lies between two parallel planes                           |
 
 ## Implementation strategy
@@ -121,24 +121,24 @@ trait Meshable{
   fn mesh(&self) -> Mesh;
 };
 
-trait Bounding3d {
-  fn within(&self, other: &impl Bounding3d) -> bool;
-  fn contains(&self, collider: &impl Collider3d) -> bool;
-}
-
 trait Bounding2d {
   fn within(&self, other: &impl Bounding2d) -> bool;
   fn contains(&self, collider: &impl Collider2d) -> bool;
 }
 
-trait Collider3d {
-  fn collide(&self, other: &impl Collider3d) -> Option(Collision3d);
-  fn within(&self, bounds: &impl Bounding3d) -> bool;
+trait Bounding3d {
+  fn within(&self, other: &impl Bounding3d) -> bool;
+  fn contains(&self, collider: &impl Collider3d) -> bool;
 }
 
 trait Collider2d {
   fn collide(&self, other: &impl Collider2d) -> Option(Collision2d);
   fn within(&self, bounds: &impl Bounding2d) -> bool;
+}
+
+trait Collider3d {
+  fn collide(&self, other: &impl Collider3d) -> Option(Collision3d);
+  fn within(&self, bounds: &impl Bounding3d) -> bool;
 }
 ```
 ### 2D Geometry Types
@@ -168,7 +168,7 @@ struct LineSegment2d {
 }
 impl Meshable for LineSegment2d {}
 
-/// 
+/// A line drawn along a path of vertices 
 struct PolyLine2d<const N: usize>{
   points: [Point2d; N],
 }

--- a/rfcs/12-primitive-shapes.md
+++ b/rfcs/12-primitive-shapes.md
@@ -92,7 +92,7 @@ This RFC provides independent 2d and 3d primitives. Recall that the purpose of t
 | Cone            | -               | Cone          |
 | Wedge           | -               | Wedge         |
 | Torus           | -               | Torus         |
-| Frustrum        | -               | Frustrum      |
+| Frustum         | -               | Frustum       |
 | RegularPolygon  | RegularPolygon  | -             |
 | Polygon         | Polygon         | -             |
 | Rectangle       | Rectangle       | -             |

--- a/rfcs/12-primitive-shapes.md
+++ b/rfcs/12-primitive-shapes.md
@@ -100,7 +100,7 @@ The complete overview of shapes, their dimensions and their names can be seen in
 | Capsule         | -               | Capsule       | A capsule with its origin at the center of the volume                                    |
 | Cone            | -               | Cone          | A cone with the origin located at the center of the circular base                        |
 | Wedge           | -               | Wedge         | A ramp with the origin centered on the width, and coincident with the rear vertical wall |
-| Torus           | -               | Torus         | A torous                                                                                 |
+| Torus           | -               | Torus         | A torus, shaped like a donut                                                                           |
 | Frustum         | -               | Frustum       | The portion of a pyramid that lies between two parallel planes                           |
 
 ## Implementation strategy

--- a/rfcs/12-primitive-shapes.md
+++ b/rfcs/12-primitive-shapes.md
@@ -551,10 +551,6 @@ Prior art was used to select the most common types of shape primitive, naming co
 
 Many game engine docs appear to have oddly-named and disconnected shape primitive types that are completely unrelated. This RFC aims to ensure Bevy doesn't go down this path, and instead derives functionality from common types to take advantage of the composability of components in the ECS.
 
-## Unresolved questions
-
-What is the best naming scheme, e.g., `2d::Line`/`3d::Line` vs. `Line2d`/`Line3d` vs. `Line2d`/`Line`?
-
 ### Out of Scope
 
 * Value types, e.g. float vs. fixed is out of scope. This RFC is focused on the core geometry types and is intended to use Bevy's common rendering value types such as `f32`.

--- a/rfcs/12-primitive-shapes.md
+++ b/rfcs/12-primitive-shapes.md
@@ -72,7 +72,12 @@ Colliders can provide intersection checks against other colliders, as well as ch
 
 ### 2D and 3D
 
-This RFC provides independent 2d and 3d primitives. Recall that the purpose of this is to provide lightweight types, so there are what appear to be duplicates in 2d and 3d, such as `Line2d` and `Line3d`. Note that the 2d version of a line is smaller than its 3d counterpart because it is only defined in 2d.
+This RFC provides independent 2d and 3d primitives. Types that are present in both 2d and 3d space are suffixed with "2d" or "3d" to disambiguate them such as `Line2d` and `Line3d`. Types that only exist in either space have no suffix. 
+
+* 2D shapes have their dimensions defined in `x` and `y`. 
+* 3D shapes have their dimensions defined in `x`, `y` and `z`
+
+The complete overview of shapes, their dimensions and their names can be seen in this table:
 
 | Shape           | 2D              | 3D            | Description                                                                              |
 |-----------------|-----------------|---------------|------------------------------------------------------------------------------------------|
@@ -137,8 +142,6 @@ trait Collider2d {
 }
 ```
 ### 2D Geometry Types
-
-These types exist in 2d space: their dimensions and location are only defined in `x` and `y` unlike their 3d counterparts. Types that are present in both 2d and 3d space are suffixed with "2d" to disambiguate from the 3d types in user code. Types that only exist in 2d space have no "2d" suffix.
 
 ```rust
 struct Point2d(Vec2)
@@ -268,8 +271,6 @@ impl Collider2d for CapsuleCollider2d {}
 ```
 
 ### 3D Geometry Types
-
-These types exist in 3d space: their dimensions and location are defined in `x`, `y` and `z`. Types that are present in both 2d and 3d space are suffixed with "3d" to disambiguate from the 2d types in user code. Types that only exist in 3d space have no "3d" suffix.
 
 ```rust
 struct Point3d(Vec3)

--- a/rfcs/12-primitive-shapes.md
+++ b/rfcs/12-primitive-shapes.md
@@ -23,15 +23,15 @@ pub struct Circle {
 Note that a `Circle` does not contain any information about the position of the circle. This is due to how shapes are composed to add more complex functionality. Consider the following common use cases of primitives shapes, as well as the the information (Translation and Rotation) that are needed to fully define the shapes for these cases:
 
 | Shape     | Mesh | Bounding | Collision |
-|---        |---|---|---|
-| Sphere    | ✔ | ✔  + Trans | ✔ + Trans |
+|-----------|----|------------------|---|
+| Sphere    | ✔ | ✔  + Trans       | ✔ + Trans |
 | Box       | ✔ | ✔ + Trans (AABB) | ✔ + Trans + Rot (OBB) |
-| Capsule   | ✔ | ❌ | ✔ + Trans + Rot |
-| Cylinder  | ✔ | ❌ | ✔ + Trans + Rot |
-| Cone      | ✔ | ❌ | ✔ + Trans + Rot |
-| Wedge     | ✔ | ❌ | ✔ + Trans + Rot |
-| Plane     | ✔ | ❌ | ✔ |
-| Torus     | ✔ | ❌ | ❌ |
+| Capsule   | ✔ | ❌               | ✔ + Trans + Rot |
+| Cylinder  | ✔ | ❌               | ✔ + Trans + Rot |
+| Cone      | ✔ | ❌               | ✔ + Trans + Rot |
+| Wedge     | ✔ | ❌               | ✔ + Trans + Rot |
+| Plane     | ✔ | ❌               | ✔ |
+| Torus     | ✔ | ❌               | ❌ |
 
 ### Bounding vs. Collision
 
@@ -70,33 +70,33 @@ For use in spatial queries, broad phase collision detection, and raycasting, hyp
 
 Colliders can provide intersection checks against other colliders, as well as check if they are within a bounding volume.
 
-### 3D and 2D
+### 2D and 3D
 
 This RFC provides independent 2d and 3d primitives. Recall that the purpose of this is to provide lightweight types, so there are what appear to be duplicates in 2d and 3d, such as `Line2d` and `Line3d`. Note that the 2d version of a line is smaller than its 3d counterpart because it is only defined in 2d.
 
-| Shape           | 2D              | 3D            |
-|-----------------|-----------------|---------------|
-| Rectangle       | Rectangle       | -             |
-| Circle          | Circle          | -             |
-| Polygon         | Polygon         | -             |
-| RegularPolygon  | RegularPolygon  | -             |
-| Point           | Point2d         | Point3d       |
-| Plane           | Plane2d         | Plane3d       |
-| Direction       | Direction2d     | Direction3d   |
-| Ray             | Ray2d           | Ray3d         |
-| Line            | Line2d          | Line3d        |
-| LineSegment     | LineSegment2d   | LineSegment3d |
-| Polyline        | Polyline2d      | Polyline3d    |
-| Triangle        | Triangle2d      | Triangle3d    |
-| Quad            | Quad2d          | Quad3d        |
-| Sphere          | -               | Sphere        |
-| Box             | -               | Box           |
-| Cylinder        | -               | Cylinder      |
-| Capsule         | -               | Capsule       |
-| Cone            | -               | Cone          |
-| Wedge           | -               | Wedge         |
-| Torus           | -               | Torus         |
-| Frustum         | -               | Frustum       |
+| Shape           | 2D              | 3D            | Description                                                                              |
+|-----------------|-----------------|---------------|------------------------------------------------------------------------------------------|
+| Rectangle       | Rectangle       | -             | A rectangle defined by its width and height                                              |
+| Circle          | Circle          | -             | A circle defined by its radius                                                           |
+| Polygon         | Polygon         | -             | A closed shape in a plane defined by a finite number of line-segments between vertices   |
+| RegularPolygon  | RegularPolygon  | -             | A polygon where all vertices lies on the circumscribed circle, equally far apart         |
+| Point           | Point2d         | Point3d       | A single point in space                                                                  |
+| Plane           | Plane2d         | Plane3d       | An unbounded plane defined by a position and normal                                      |
+| Direction       | Direction2d     | Direction3d   | A normalized vector pointing in a direction                                              |
+| Ray             | Ray2d           | Ray3d         | An infinite half-line pointing in a direction                                            |
+| Line            | Line2d          | Line3d        | An infinite line                                                                         |
+| LineSegment     | LineSegment2d   | LineSegment3d | A finite line between two vertices                                                       |
+| Polyline        | Polyline2d      | Polyline3d    | A line drawn along a path of vertices                                                    |
+| Triangle        | Triangle2d      | Triangle3d    | A polygon with 3 vertices                                                                |
+| Quad            | Quad2d          | Quad3d        | A polygon with 4 vertices                                                                |
+| Sphere          | -               | Sphere        | A sphere defined by its radius                                                           |
+| Box             | -               | Box           | A cuboid with six quadrilateral faces, defined by height, width, depth                   |
+| Cylinder        | -               | Cylinder      | A cylinder with its origin at the center of the volume                                   |
+| Capsule         | -               | Capsule       | A capsule with its origin at the center of the volume                                    |
+| Cone            | -               | Cone          | A cone with the origin located at the center of the circular base                        |
+| Wedge           | -               | Wedge         | A ramp with the origin centered on the width, and coincident with the rear vertical wall |
+| Torus           | -               | Torus         | A torous                                                                                 |
+| Frustum         | -               | Frustum       | The portion of a pyramid that lies between two parallel planes                           |
 
 ## Implementation strategy
 
@@ -138,7 +138,7 @@ trait Collider2d {
 ```
 ### 2D Geometry Types
 
-These types only exist in 2d space: their dimensions and location are only defined in `x` and `y` unlike their 3d counterparts. These types are suffixed with "2d" to disambiguate from the 3d types in user code, guide users to using 3d types by default, and remove the need for name-spacing the 2d and 3d types when used in the same scope.
+These types exist in 2d space: their dimensions and location are only defined in `x` and `y` unlike their 3d counterparts. Types that are present in both 2d and 3d space are suffixed with "2d" to disambiguate from the 3d types in user code. Types that only exist in 2d space have no "2d" suffix.
 
 ```rust
 struct Point2d(Vec2)
@@ -158,12 +158,14 @@ struct Line2d {
 }
 impl Meshable for Line2d {}
 
+/// A finite line between two vertices
 struct LineSegment2d { 
   start: Point2d, 
   end: Point2d,
 }
 impl Meshable for LineSegment2d {}
 
+/// 
 struct PolyLine2d<const N: usize>{
   points: [Point2d; N],
 }
@@ -175,7 +177,14 @@ impl Meshable for Triangle2d {}
 struct Quad2d([Point2d; 4]);
 impl Meshable for Quad2d {}
 
-/// A regular polygon, such as a square or hexagon.
+/// A closed shape in a plane defined by a finite number of line-segments between vertices
+struct Polygon2d <const N: usize>{
+  points: [Point2d; N],
+}
+impl Meshable for Polygon2d {}
+
+/// A polygon where all vertices lies on the circumscribed circle, equally far apart
+/// Example: Square, Triangle, Hexagon
 struct RegularPolygon2d {
   /// The circumcircle that all points of the regular polygon lie on.
   circumcircle: Circle2d,
@@ -185,14 +194,11 @@ struct RegularPolygon2d {
   orientation: Angle,
 }
 impl Meshable for RegularPolygon2d {}
- 
-struct Polygon2d <const N: usize>{
-  points: [Point2d; N],
-}
-impl Meshable for Polygon2d {}
 
-/// Circle types
 
+// Circle types
+
+/// A circle defined by its radius
 struct Circle {
   radius: f32,
 }
@@ -216,6 +222,7 @@ impl Collider2d for CircleCollider {}
 
 // Box Types
 
+/// A rectangle defined by its width and height
 struct Rectangle {
   half_extents: Vec2,
 }
@@ -261,6 +268,8 @@ impl Collider2d for CapsuleCollider2d {}
 ```
 
 ### 3D Geometry Types
+
+These types exist in 3d space: their dimensions and location are defined in `x`, `y` and `z`. Types that are present in both 2d and 3d space are suffixed with "3d" to disambiguate from the 2d types in user code. Types that only exist in 3d space have no "3d" suffix.
 
 ```rust
 struct Point3d(Vec3)
@@ -312,7 +321,7 @@ struct Quad3d([Point3d; 4]);
 impl Meshable for Quad3d {}
 impl Collider for Quad3d {}
 
-/// Sphere types
+// Sphere types
 
 struct Sphere {
   radius: f32,
@@ -446,7 +455,7 @@ struct Torus {
 }
 impl Meshable for Torus {}
 
-// A 3d frustum used to represent the volume rendered by a camera, defined by the 6 planes that set the frustum limits.
+/// A 3d frustum used to represent the volume rendered by a camera, defined by the 6 planes that set the frustum limits.
 struct Frustum {
   near: Plane3d,
   far: Plane3d,
@@ -458,7 +467,6 @@ struct Frustum {
 impl Meshable for Frustum {}
 
 ```
-
 
 ### Bounding and Collision
 


### PR DESCRIPTION
These are my attempts at solving the naming-scheme question as answered here: https://github.com/bevyengine/rfcs/pull/12#discussion_r680267479

### Solution
* Rename shapes to adhere to `x3d` and `x2d`  naming scheme where possible
* Shapes that only exists in 2d or 3d does not have a `2d` or `3d` suffix
* Renamed `Box2d` to `Rectangle`

[Changes best seen in this table](https://github.com/aevyrie/rfcs/compare/patch-1...Weibye:name-consolidation?expand=1#diff-ec750729cebb6aedfc315644b1fe7e02c7e2839daf399ec925a274f6f944d87fR77)

### Unresolved questions

* Is the `Capsule2d` required? Would it not be better to use the regular `Capsule` shape but combine it with a `Vec2` or `Point2` for positioning?

I'm not very well experienced with either Bevy nor rust, so let me know if these changes doesn't make much sense at all.

