### PR TITLE
Remove angle as a component

### DIFF
--- a/rfcs/12-primitive-shapes.md
+++ b/rfcs/12-primitive-shapes.md
@@ -105,13 +105,6 @@ The complete overview of shapes, their dimensions and their names can be seen in
 
 ## Implementation strategy
 
-### Helper Types
-
-```rust
-/// Stores an angle in radians, and supplies builder functions to prevent errors (from_radians, from_degrees)
-struct Angle(f32);
-```
-
 ### Traits (REFERENCE ONLY!)
 
 **These traits are provided as reference to illustrate how these primitive shape types might be used. The details of implementation and interface should be determined in a separate RFC, PR, or independent prototypes.**
@@ -194,7 +187,7 @@ struct RegularPolygon2d {
   /// Number of faces.
   faces: u8,
   /// Clockwise rotation of the polygon about the origin. At zero rotation, a point will always be located at the 12 o'clock position.
-  orientation: Angle,
+  orientation: f32,
 }
 impl Meshable for RegularPolygon2d {}
 


### PR DESCRIPTION
Removes angle as a primitive. It was suggested by[ Cart to punt the discussion on the angle](https://github.com/bevyengine/rfcs/pull/12#discussion_r680261521), so I'm removing it. 